### PR TITLE
Loosen deps on base and text

### DIFF
--- a/drifter.cabal
+++ b/drifter.cabal
@@ -21,10 +21,10 @@ library
     hs-source-dirs:     src
     default-language:   Haskell2010
 
-    build-depends:      base                >=4.7   && <4.8
+    build-depends:      base                >=4.6   && <4.8
                     ,   fgl                 >=5.5   && <5.6
                     ,   containers          >=0.5   && <0.6
-                    ,   text                >=1.2   && <1.3
+                    ,   text                >=0.11   && <1.3
 
     exposed-modules:    Drifter.Graph
                     ,   Drifter.Types


### PR DESCRIPTION
Both of these constraints were too strict. We could probably even go
much lower on text but 0.11 is definitely safe. The base constraint was
preventing this from building on GHC 7.6
